### PR TITLE
fix: correct row_template path in Newsletter get_list_context

### DIFF
--- a/newsletter/newsletter/doctype/newsletter/newsletter.py
+++ b/newsletter/newsletter/doctype/newsletter/newsletter.py
@@ -397,7 +397,8 @@ def get_list_context(context=None):
 			"no_breadcrumbs": True,
 			"title": _("Newsletters"),
 			"filters": {"published": 1},
-			"row_template": "email/doctype/newsletter/templates/newsletter_row.html",
+			"row_template": "newsletter/doctype/newsletter/templates/newsletter_row.html",
+			"list_template": "templates/includes/list/list.html",
 		}
 	)
 


### PR DESCRIPTION
fix(portal): correct Newsletter row_template path in get_list_context

Closes #14

Newsletter portal list view fails with TemplateNotFound error due to incorrect row_template path.

Fix:

row_template: "newsletter/doctype/newsletter/templates/newsletter_row.html"
list_template: "templates/includes/list/list.html"
Tested: Portal /newsletters now renders correctly with no errors.

📸 Screenshots
✅ Working Newsletter in Portal (After Fix)
<img width="848" height="422" alt="newsletter_portal_record" src="https://github.com/user-attachments/assets/53d6ee49-29b6-4b52-80b1-bfdb6b507fcf" />
<img width="1198" height="967" alt="newsletter_portal_list" src="https://github.com/user-attachments/assets/58c73c9b-cab3-43a5-899d-ed0a1daac7e6" />
